### PR TITLE
Bugfix: Skew fixed for 'mt' and 'mb' action on custom action override 

### DIFF
--- a/dist/customiseControls.js
+++ b/dist/customiseControls.js
@@ -563,7 +563,7 @@
                         case 'mb':
                             if (e[this.altActionKey]) {
                                 return e[this.altActionKey]
-                                    ? 'skewY'
+                                    ? 'skewX'
                                     : 'scaleY';
                             }
                             return this[corner + 'Action'];


### PR DESCRIPTION
Super-simple bugfix: 
When custom action is present and the modifier-key is pressed, the 'mb' and 'mt' control should skewX and not skewY, this is how the controls works when there's no custom action override.